### PR TITLE
#11  Maps with early notes aren't transformed after Beat Saber 1.13

### DIFF
--- a/AlternativePlay/GameModifiersBehavior.cs
+++ b/AlternativePlay/GameModifiersBehavior.cs
@@ -69,7 +69,7 @@ namespace AlternativePlay
 
         private IEnumerator TransformMap()
         {
-            yield return new WaitForSecondsRealtime(0.1f);
+            yield return new WaitForSecondsRealtime(0.01f);
             if (BS_Utils.Plugin.LevelData.Mode == BS_Utils.Gameplay.Mode.Multiplayer) { yield break; }
 
             var config = Configuration.instance.ConfigurationData;


### PR DESCRIPTION
Decreased transform map wait time to 0.01f
Closes #11 