### PR TITLE
#56 GameModifiersBehavior do not work in Beat Saber 1.27

### DIFF
--- a/AlternativePlay/GameModifiersBehavior.cs
+++ b/AlternativePlay/GameModifiersBehavior.cs
@@ -118,7 +118,7 @@ namespace AlternativePlay
         {
             var config = Configuration.instance.ConfigurationData;
 
-            foreach (NoteData note in beatmapData.GetBeatmapDataItems<NoteData>())
+            foreach (NoteData note in beatmapData.GetBeatmapDataItems<NoteData>(0))
             {
                 // Transform for NoArrows or TouchNotes here but do not if NoArrowsRandom was already applied
                 if ((config.NoArrows || config.TouchNotes) && !config.NoArrowsRandom)
@@ -150,11 +150,11 @@ namespace AlternativePlay
             if (config.NoSliders)
             {
                 // Remove all Burst Sliders from list
-                var burstSliders = beatmapData.GetBeatmapDataItems<SliderData>().Where(s => s.sliderType == SliderData.Type.Burst).ToList();
+                var burstSliders = beatmapData.GetBeatmapDataItems<SliderData>(0).Where(s => s.sliderType == SliderData.Type.Burst).ToList();
                 burstSliders.ForEach(s => beatmapData.allBeatmapDataItems.Remove(s));
             }
 
-            foreach (SliderData slider in beatmapData.GetBeatmapDataItems<SliderData>())
+            foreach (SliderData slider in beatmapData.GetBeatmapDataItems<SliderData>(0))
             {
                 // Transform for One Color if this is the other note type
                 if (config.OneColor && slider.colorType == undesiredNoteType)

--- a/AlternativePlay/Properties/AssemblyInfo.cs
+++ b/AlternativePlay/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Kylon99")]
 [assembly: AssemblyProduct("AlternativePlay")]
-[assembly: AssemblyCopyright("Copyright © 2022")]
+[assembly: AssemblyCopyright("Copyright © 2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.3.0")]
-[assembly: AssemblyFileVersion("0.7.3.0")]
+[assembly: AssemblyVersion("0.7.5.0")]
+[assembly: AssemblyFileVersion("0.7.5.0")]

--- a/AlternativePlay/manifest.json
+++ b/AlternativePlay/manifest.json
@@ -3,15 +3,15 @@
   "author": "Kylon99",
   "description": "Darth Maul, Spear and new game play styles and modifiers for Beat Saber",
   "features": [],
-  "gameVersion": "1.21",
+  "gameVersion": "1.27",
   "icon": "AlternativePlay.Public.DarthMaulColor.png",
   "id": "AlternativePlay",
   "name": "AlternativePlay",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "dependsOn": {
     "BSIPA": "^4.2.2",
-    "BeatSaberMarkupLanguage": "^1.6.3",
-    "BS Utils": "^1.12.0"
+    "BeatSaberMarkupLanguage": "^1.6.8",
+    "BS Utils": "^1.12.1"
   },
   "links": {
     "project-home": "https://github.com/Kylon99/AlternativePlay",

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ This mod depends on the following mods.  Download them at [BeatMods](https://bea
 Drop the AlternativePlay.dll file into your Plugins folder under your BeatSaber folder.
 
 ## Changelog
+
+### 0.7.5
+- Fixed GameModifiersBehavior to support Beat Saber 1.27
+
 ### 0.7.4
 - Updated to support Beat Saber 1.21
 - Added NoSliders game modifier option


### PR DESCRIPTION
* Fixed GameModifiersBehavior to support Beat Saber 1.27.  
* Updated to 0.7.5

Closes #56 