### PR TITLE
#69 Unite 0.7.6 and 0.7.4 branches by calling GetBeatmapDataItems through reflection

### DIFF
--- a/AlternativePlay/Properties/AssemblyInfo.cs
+++ b/AlternativePlay/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.6.0")]
-[assembly: AssemblyFileVersion("0.7.6.0")]
+[assembly: AssemblyVersion("0.7.7.0")]
+[assembly: AssemblyFileVersion("0.7.7.0")]

--- a/AlternativePlay/manifest.json
+++ b/AlternativePlay/manifest.json
@@ -1,17 +1,17 @@
 ﻿{
   "$schema": "https://raw.githubusercontent.com/nike4613/ModSaber-MetadataFileSchema/master/Schema.json",
-  "author": "Kylon99",
+  "author": "KevinKylon",
   "description": "Darth Maul, Spear and new game play styles and modifiers for Beat Saber",
   "features": [],
-  "gameVersion": "1.27",
+  "gameVersion": "1.21",
   "icon": "AlternativePlay.Public.DarthMaulColor.png",
   "id": "AlternativePlay",
   "name": "AlternativePlay",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "dependsOn": {
-    "BSIPA": "^4.2.2",
-    "BeatSaberMarkupLanguage": "^1.6.8",
-    "BS Utils": "^1.12.1"
+    "BeatSaberMarkupLanguage": "^1.6.3",
+    "BS Utils": "^1.12.0",
+    "BSIPA": "^4.2.2"
   },
   "links": {
     "project-home": "https://github.com/Kylon99/AlternativePlay",

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ controller to be the 'front' hand. The spear can hit any notes of any color.
 
 ### ![IMG](AlternativePlay/Public/NunchakuColor64.png) Nunchaku
 
-Swing a simulated two segment nunchaku! Use the trigger to hold the nunchaku in that hand or press
-both triggers to hold both segments in each hand.
+Swing a simulated two segment nunchaku! You only need to use two controllers! Use the trigger to hold 
+the nunchaku in that hand or press both triggers to hold both segments in each hand.
 
 ### ![IMG](AlternativePlay/Public/BeatFlailColor64.png) Beat Flail
 
-Swing the saber around on a chain like a flail! Longer chains are harder to swing and control
-while shorter chains allow for less of a full arm swing.
+You only need two controllers! Swing the saber around on a chain like a flail without hitting yourself! 
+Longer chains are harder to swing and control while shorter chains allow for less of a full arm swing.
 
 ### ![IMG](AlternativePlay/Public/NoArrowsColor64.png) No Arrows
 ### ![IMG](AlternativePlay/Public/OneColorColor64.png) One Color
@@ -44,7 +44,9 @@ This functionality was broken by Beat Saber 1.12.  It may be restored one day.
 
 ## Tracker Selection
 
-You can now choose which trackers to use for Beat Saber, Darth Maul and Beat Spear without the need for OpenVR Input Emulator.  You can also adjust the position and rotation of the saber for when using these trackers.
+You can now choose which trackers to use for Beat Saber, Darth Maul and Beat Spear without the need for 
+OpenVR Input Emulator.  You can also adjust the position and rotation of the saber for when using these 
+trackers.
 
 ## Contributors
 
@@ -53,7 +55,9 @@ You can now choose which trackers to use for Beat Saber, Darth Maul and Beat Spe
 * Special thanks to Nullpon for testing and fixes! https://github.com/nullpon16tera
 
 ## Requirements
-This mod depends on the following mods.  Download them at [BeatMods](https://beatmods.com).
+This mod depends on the following mods.  Download them at [BeatMods](https://beatmods.com) or install them
+with [ModAssistant](https://github.com/Assistant/ModAssistant).  You might already have them if you've 
+installed other mods!
 
 * https://github.com/nike4613/BeatSaber-IPA-Reloaded/
 * https://github.com/Kylemc1413/Beat-Saber-Utils
@@ -64,6 +68,9 @@ This mod depends on the following mods.  Download them at [BeatMods](https://bea
 Drop the AlternativePlay.dll file into your Plugins folder under your BeatSaber folder.
 
 ## Changelog
+
+### 0.7.7
+- United support for Beat Saber 1.21 - 1.26 and 1.27 - 1.29.1
 
 ### 0.7.6
 - Added Updated UI to support multiple play mode settings


### PR DESCRIPTION
Used reflection to detect and call GetBeatmapDataItems with no parameters or one parameter.  Updated to version 0.7.7.  Regressed Beat Saber version to 1.21.
Closes #63 