### PR TITLE
Tracking lag issue3

### DIFF
--- a/AlternativePlay/AlternativePlay.csproj
+++ b/AlternativePlay/AlternativePlay.csproj
@@ -32,116 +32,175 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>$(GameDirPath)Libs\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.10.2.0, Culture=neutral, processorArchitecture=MSIL">
       <Private>False</Private>
-    </Reference>
-    <Reference Include="BeatSaber.GameSettings">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\BeatSaber.GameSettings.dll</HintPath>
-    </Reference>
-    <Reference Include="BeatSaber.Settings">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\BeatSaber.Settings.dll</HintPath>
-    </Reference>
-    <Reference Include="BeatSaber.ViewSystem">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\BeatSaber.ViewSystem.dll</HintPath>
-    </Reference>
-    <Reference Include="BGLib.AppFlow">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\BGLib.AppFlow.dll</HintPath>
-    </Reference>
-    <Reference Include="BGLib.UnityExtension">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\BGLib.UnityExtension.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="BeatmapCore, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
+    </Reference>
+    <Reference Include="BeatSaber.GameSettings, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.GameSettings.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="BGNetCore">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\BGNetCore.dll</HintPath>
-    </Reference>
-    <Reference Include="BSML">
-      <HintPath>$(GameDirPath)Plugins\BSML.dll</HintPath>
+    <Reference Include="BeatSaber.Settings, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.Settings.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="BS_Utils">
-      <HintPath>$(GameDirPath)Plugins\BS_Utils.dll</HintPath>
+    <Reference Include="BeatSaber.ViewSystem, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.ViewSystem.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="DataModels">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\DataModels.dll</HintPath>
+    <Reference Include="BGLib.AppFlow, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.AppFlow.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="BGLib.UnityExtension, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.UnityExtension.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="BGNetCore, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGNetCore.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="BSML, Version=1.12.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="BS_Utils, Version=1.14.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Plugins\BS_Utils.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="DataModels, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\DataModels.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="GameplayCore, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
-      <Private>False</Private>
     </Reference>
-    <Reference Include="HMLib">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\HMLib.dll</HintPath>
+    <Reference Include="HMLib, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="HMUI">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\HMUI.dll</HintPath>
+    <Reference Include="HMUI, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="IPA.Loader">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
+    <Reference Include="IPA.Loader, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="LiteNetLib, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\LiteNetLib.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\LiteNetLib.dll</HintPath>
+    </Reference>
+    <Reference Include="Main, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <Private>False</Private>
-    </Reference>
-    <Reference Include="Main">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\Main.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Networking">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\Networking.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(GameDirPath)Libs\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Unity.Mathematics">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\Unity.Mathematics.dll</HintPath>
+    <Reference Include="Microsoft.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(BeatSaberDir)\Libs\Microsoft.CSharp.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Networking, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Networking.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Libs\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\System.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\System.Data.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Data.DataSetExtensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\System.Data.DataSetExtensions.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\System.Net.Http.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\System.Xml.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Xml.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\System.Xml.Linq.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Unity.Mathematics, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.Mathematics.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Unity.XR.OpenVR, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <Private>False</Private>
-      <HintPath>E:\BSManager\BSInstances\1.40.4_mod\Libs\Unity.XR.OpenVR.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Libs\Unity.XR.OpenVR.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
-      <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+    <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="UnityEngine.XRModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\UnityEngine.XRModule.dll</HintPath>
       <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.XRModule.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="Zenject">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\Zenject.dll</HintPath>
+    <Reference Include="Zenject, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="Zenject-usage">
-      <HintPath>$(GameDirPath)Beat Saber_Data\Managed\Zenject-usage.dll</HintPath>
+    <Reference Include="Zenject-usage, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject-usage.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/AlternativePlay/AlternativePlay.csproj
+++ b/AlternativePlay/AlternativePlay.csproj
@@ -115,8 +115,10 @@
     <Reference Include="Unity.Mathematics">
       <HintPath>$(GameDirPath)Beat Saber_Data\Managed\Unity.Mathematics.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.XR.OpenVR">
-      <HintPath>$(GameDirPath)Libs\OpenVR\Unity.XR.OpenVR.dll</HintPath>
+    <Reference Include="Unity.XR.OpenVR, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>E:\BSManager\BSInstances\1.40.4_mod\Libs\Unity.XR.OpenVR.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/AlternativePlay/DarthMaulBehavior.cs
+++ b/AlternativePlay/DarthMaulBehavior.cs
@@ -49,6 +49,17 @@ namespace AlternativePlay
             this.TransformSabers();
         }
 
+        private void LateUpdate()
+        {
+            if (this.configuration.Current.PlayMode != PlayMode.DarthMaul)
+                return;
+            if (this.Split)
+                return;
+
+            this.saberDeviceManager.PollTrackedDevices();
+            this.TransformTwoControllerMaul();
+        }
+
         /// <summary>
         /// Move the sabers that have been disconnected from the VRControllers ourselves
         /// </summary>

--- a/AlternativePlay/DarthMaulBehavior.cs
+++ b/AlternativePlay/DarthMaulBehavior.cs
@@ -55,6 +55,9 @@ namespace AlternativePlay
                 return;
             if (this.Split)
                 return;
+            // Only two-controller maul repolls in LateUpdate; one-controller is handled entirely in Update.
+            if (this.configuration.Current.ControllerCount != ControllerCountEnum.Two)
+                return;
 
             this.saberDeviceManager.PollTrackedDevices();
             this.TransformTwoControllerMaul();

--- a/AlternativePlay/HarmonyPatches/DarthMaulHapticPatch.cs
+++ b/AlternativePlay/HarmonyPatches/DarthMaulHapticPatch.cs
@@ -38,19 +38,8 @@ namespace AlternativePlay.HarmonyPatches
                 return;
             }
 
-            if (Configuration.Current.ControllerCount == ControllerCountEnum.Two && Configuration.Current.ReverseMaulDirection)
-            {
-                // If reversing direction with two controller then always swap hands
-                if (node == XRNode.LeftHand)
-                {
-                    node = XRNode.RightHand;
-                }
-
-                if (node == XRNode.RightHand)
-                {
-                    node = XRNode.LeftHand;
-                }
-            }
+            // Two-controller Darth Maul: do not remap haptics. ReverseMaulDirection only changes saber poses in
+            // DarthMaulBehavior; hits still correspond to left/right saber → left/right controller as in vanilla.
         }
     }
 }

--- a/AlternativePlay/Models/OpenVRManager.cs
+++ b/AlternativePlay/Models/OpenVRManager.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using Valve.VR;
 
 namespace AlternativePlay.Models
@@ -13,13 +12,81 @@ namespace AlternativePlay.Models
 
         public OpenVRManager()
         {
-            var error = EVRInitError.None;
-            this.System = OpenVR.Init(ref error, EVRApplicationType.VRApplication_Other);
+            TryLoadOpenVrNativeLibrary();
 
-            if (error != EVRInitError.None)
+            try
             {
-                AlternativePlay.Logger.Error($"Unable to initialize OpenVR with error: {error.ToString()}");
+                var error = EVRInitError.None;
+                this.System = OpenVR.Init(ref error, EVRApplicationType.VRApplication_Other);
+
+                if (this.System == null || error != EVRInitError.None)
+                {
+                    if (error != EVRInitError.None)
+                        AlternativePlay.Logger.Error($"Unable to initialize OpenVR with error: {error}");
+                    this.System = null;
+                }
             }
+            catch (DllNotFoundException ex)
+            {
+                AlternativePlay.Logger.Error($"OpenVR native library (openvr_api) not found; tracker and controller polling are disabled. {ex.Message}");
+                this.System = null;
+            }
+            catch (Exception ex)
+            {
+                AlternativePlay.Logger.Error($"OpenVR initialization failed: {ex.Message}");
+                this.System = null;
+            }
+        }
+
+        /// <summary>
+        /// Loads {GameRoot}/Libs/OpenVR/openvr_api.dll before Valve.VR P/Invoke runs, so the loader can find the DLL.
+        /// </summary>
+        private static void TryLoadOpenVrNativeLibrary()
+        {
+            try
+            {
+                string path = ResolveOpenVrApiPath();
+                if (string.IsNullOrEmpty(path))
+                    return;
+
+                IntPtr handle = NativeMethods.LoadLibrary(path);
+                if (handle == IntPtr.Zero)
+                {
+                    int err = Marshal.GetLastWin32Error();
+                    AlternativePlay.Logger.Error($"LoadLibrary failed for OpenVR ({path}), Win32 error {err}");
+                    return;
+                }
+
+                AlternativePlay.Logger.Info($"Preloaded OpenVR native library from {path}");
+            }
+            catch (Exception ex)
+            {
+                AlternativePlay.Logger.Error($"Could not preload OpenVR native library: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// AlternativePlay.dll is in Plugins/; game root is the parent folder (contains Libs/OpenVR/).
+        /// </summary>
+        private static string ResolveOpenVrApiPath()
+        {
+            string location = Assembly.GetExecutingAssembly().Location;
+            if (string.IsNullOrEmpty(location))
+                return null;
+
+            string pluginDir = Path.GetDirectoryName(location);
+            string gameRoot = Path.GetDirectoryName(pluginDir);
+            if (string.IsNullOrEmpty(gameRoot))
+                return null;
+
+            string candidate = Path.GetFullPath(Path.Combine(gameRoot, "Libs", "OpenVR", "openvr_api.dll"));
+            return File.Exists(candidate) ? candidate : null;
+        }
+
+        private static class NativeMethods
+        {
+            [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Unicode)]
+            public static extern IntPtr LoadLibrary(string lpFileName);
         }
     }
 }

--- a/AlternativePlay/Models/OpenVRManager.cs
+++ b/AlternativePlay/Models/OpenVRManager.cs
@@ -1,7 +1,8 @@
 using System;
-using System.IO;
-using System.Reflection;
-using System.Runtime.InteropServices;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 using Valve.VR;
 
 namespace AlternativePlay.Models
@@ -12,81 +13,13 @@ namespace AlternativePlay.Models
 
         public OpenVRManager()
         {
-            TryLoadOpenVrNativeLibrary();
+            var error = EVRInitError.None;
+            this.System = OpenVR.Init(ref error, EVRApplicationType.VRApplication_Other);
 
-            try
+            if (error != EVRInitError.None)
             {
-                var error = EVRInitError.None;
-                this.System = OpenVR.Init(ref error, EVRApplicationType.VRApplication_Other);
-
-                if (this.System == null || error != EVRInitError.None)
-                {
-                    if (error != EVRInitError.None)
-                        AlternativePlay.Logger.Error($"Unable to initialize OpenVR with error: {error}");
-                    this.System = null;
-                }
+                AlternativePlay.Logger.Error($"Unable to initialize OpenVR with error: {error.ToString()}");
             }
-            catch (DllNotFoundException ex)
-            {
-                AlternativePlay.Logger.Error($"OpenVR native library (openvr_api) not found; tracker and controller polling are disabled. {ex.Message}");
-                this.System = null;
-            }
-            catch (Exception ex)
-            {
-                AlternativePlay.Logger.Error($"OpenVR initialization failed: {ex.Message}");
-                this.System = null;
-            }
-        }
-
-        /// <summary>
-        /// Loads {GameRoot}/Libs/OpenVR/openvr_api.dll before Valve.VR P/Invoke runs, so the loader can find the DLL.
-        /// </summary>
-        private static void TryLoadOpenVrNativeLibrary()
-        {
-            try
-            {
-                string path = ResolveOpenVrApiPath();
-                if (string.IsNullOrEmpty(path))
-                    return;
-
-                IntPtr handle = NativeMethods.LoadLibrary(path);
-                if (handle == IntPtr.Zero)
-                {
-                    int err = Marshal.GetLastWin32Error();
-                    AlternativePlay.Logger.Error($"LoadLibrary failed for OpenVR ({path}), Win32 error {err}");
-                    return;
-                }
-
-                AlternativePlay.Logger.Info($"Preloaded OpenVR native library from {path}");
-            }
-            catch (Exception ex)
-            {
-                AlternativePlay.Logger.Error($"Could not preload OpenVR native library: {ex.Message}");
-            }
-        }
-
-        /// <summary>
-        /// AlternativePlay.dll is in Plugins/; game root is the parent folder (contains Libs/OpenVR/).
-        /// </summary>
-        private static string ResolveOpenVrApiPath()
-        {
-            string location = Assembly.GetExecutingAssembly().Location;
-            if (string.IsNullOrEmpty(location))
-                return null;
-
-            string pluginDir = Path.GetDirectoryName(location);
-            string gameRoot = Path.GetDirectoryName(pluginDir);
-            if (string.IsNullOrEmpty(gameRoot))
-                return null;
-
-            string candidate = Path.GetFullPath(Path.Combine(gameRoot, "Libs", "OpenVR", "openvr_api.dll"));
-            return File.Exists(candidate) ? candidate : null;
-        }
-
-        private static class NativeMethods
-        {
-            [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Unicode)]
-            public static extern IntPtr LoadLibrary(string lpFileName);
         }
     }
 }

--- a/AlternativePlay/Models/TrackedDeviceManager.cs
+++ b/AlternativePlay/Models/TrackedDeviceManager.cs
@@ -31,6 +31,20 @@ namespace AlternativePlay.Models
     /// </summary>
     public class TrackedDeviceManager
     {
+        /// <summary>
+        /// OpenVR pose prediction tuning (seconds). Adjust these when experimenting with motion-to-photon latency.
+        /// </summary>
+        public static float FallbackDisplayFrequencyHz = 90f;
+
+        public static float MinPredictionSeconds = 0f;
+
+        public static float MaxPredictionSeconds = 0.05f;
+
+        /// <summary>
+        /// Added to the computed prediction before clamping to min/max (can be negative).
+        /// </summary>
+        public static float PredictionBiasSeconds = 1.5f;
+
 #pragma warning disable CS0649
         [Inject]
         private OpenVRManager openVRManager;
@@ -113,6 +127,7 @@ namespace AlternativePlay.Models
         /// <summary>
         /// Estimates seconds from now until display photons for OpenVR pose prediction.
         /// Falls back to 0 when timing cannot be read (same as the previous fixed 0f argument).
+        /// Tuning: <see cref="FallbackDisplayFrequencyHz"/>, <see cref="MinPredictionSeconds"/>, <see cref="MaxPredictionSeconds"/>, <see cref="PredictionBiasSeconds"/>.
         /// </summary>
         private float GetPredictedSecondsToPhotonsFromNow()
         {
@@ -127,7 +142,7 @@ namespace AlternativePlay.Models
             var error = ETrackedPropertyError.TrackedProp_Success;
             float displayFrequency = system.GetFloatTrackedDeviceProperty(OpenVR.k_unTrackedDeviceIndex_Hmd, ETrackedDeviceProperty.Prop_DisplayFrequency_Float, ref error);
             if (error != ETrackedPropertyError.TrackedProp_Success || displayFrequency <= 1f)
-                displayFrequency = 90f;
+                displayFrequency = FallbackDisplayFrequencyHz;
 
             error = ETrackedPropertyError.TrackedProp_Success;
             float secondsFromVsyncToPhotons = system.GetFloatTrackedDeviceProperty(OpenVR.k_unTrackedDeviceIndex_Hmd, ETrackedDeviceProperty.Prop_SecondsFromVsyncToPhotons_Float, ref error);
@@ -136,9 +151,10 @@ namespace AlternativePlay.Models
 
             float frameDuration = 1f / displayFrequency;
             float predicted = frameDuration - secondsSinceLastVsync + secondsFromVsyncToPhotons;
+            predicted += PredictionBiasSeconds;
 
-            if (predicted < 0f) predicted = 0f;
-            if (predicted > 0.05f) predicted = 0.05f;
+            if (predicted < MinPredictionSeconds) predicted = MinPredictionSeconds;
+            if (predicted > MaxPredictionSeconds) predicted = MaxPredictionSeconds;
 
             return predicted;
         }

--- a/AlternativePlay/Models/TrackedDeviceManager.cs
+++ b/AlternativePlay/Models/TrackedDeviceManager.cs
@@ -44,6 +44,12 @@ namespace AlternativePlay.Models
         /// </summary>
         public void LoadTrackedDeviceProperties()
         {
+            if (this.openVRManager?.System == null)
+            {
+                this.TrackedDevices = new List<OpenVRDeviceInfo>();
+                return;
+            }
+
             // Get a list of all valid tracked devices up to OpenVR's maximum
             this.TrackedDevices = Enumerable.Range(0, (int)OpenVR.k_unMaxTrackedDeviceCount).Select(i =>
                 new OpenVRDeviceInfo
@@ -84,6 +90,9 @@ namespace AlternativePlay.Models
         /// </remarks>
         public void PollTrackedDevices()
         {
+            if (this.openVRManager?.System == null)
+                return;
+
             // Get all tracked device poses from OpenVR API (predict forward toward photon time to reduce motion-to-photon latency)
             var pTrackedDevicePoseArray = new TrackedDevicePose_t[OpenVR.k_unMaxTrackedDeviceCount];
             float predictedSecondsToPhotons = this.GetPredictedSecondsToPhotonsFromNow();
@@ -161,6 +170,9 @@ namespace AlternativePlay.Models
 
         public Pose? GetPoseFromLeftController()
         {
+            if (this.openVRManager?.System == null)
+                return null;
+
             uint index = this.openVRManager.System.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.LeftHand);
             var device = this.TrackedDevices.ElementAtOrDefault((int)index);
 
@@ -171,6 +183,9 @@ namespace AlternativePlay.Models
 
         public Pose? GetPoseFromRightController()
         {
+            if (this.openVRManager?.System == null)
+                return null;
+
             uint index = this.openVRManager.System.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.RightHand);
             var device = this.TrackedDevices.ElementAtOrDefault((int)index);
 

--- a/AlternativePlay/Models/TrackedDeviceManager.cs
+++ b/AlternativePlay/Models/TrackedDeviceManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
@@ -84,9 +84,10 @@ namespace AlternativePlay.Models
         /// </remarks>
         public void PollTrackedDevices()
         {
-            // Get all tracked device poses from OpenVR API
+            // Get all tracked device poses from OpenVR API (predict forward toward photon time to reduce motion-to-photon latency)
             var pTrackedDevicePoseArray = new TrackedDevicePose_t[OpenVR.k_unMaxTrackedDeviceCount];
-            this.openVRManager.System.GetDeviceToAbsoluteTrackingPose(ETrackingUniverseOrigin.TrackingUniverseStanding, 0.0f, pTrackedDevicePoseArray);
+            float predictedSecondsToPhotons = this.GetPredictedSecondsToPhotonsFromNow();
+            this.openVRManager.System.GetDeviceToAbsoluteTrackingPose(ETrackingUniverseOrigin.TrackingUniverseStanding, predictedSecondsToPhotons, pTrackedDevicePoseArray);
 
             int i = 0;
             this.TrackedDevices.ForEach(device =>
@@ -100,6 +101,39 @@ namespace AlternativePlay.Models
                 }
                 i++;
             });
+        }
+
+        /// <summary>
+        /// Estimates seconds from now until display photons for OpenVR pose prediction.
+        /// Falls back to 0 when timing cannot be read (same as the previous fixed 0f argument).
+        /// </summary>
+        private float GetPredictedSecondsToPhotonsFromNow()
+        {
+            var system = this.openVRManager?.System;
+            if (system == null) return 0f;
+
+            float secondsSinceLastVsync = 0f;
+            ulong frameCounter = 0;
+            if (!system.GetTimeSinceLastVsync(ref secondsSinceLastVsync, ref frameCounter))
+                return 0f;
+
+            var error = ETrackedPropertyError.TrackedProp_Success;
+            float displayFrequency = system.GetFloatTrackedDeviceProperty(OpenVR.k_unTrackedDeviceIndex_Hmd, ETrackedDeviceProperty.Prop_DisplayFrequency_Float, ref error);
+            if (error != ETrackedPropertyError.TrackedProp_Success || displayFrequency <= 1f)
+                displayFrequency = 90f;
+
+            error = ETrackedPropertyError.TrackedProp_Success;
+            float secondsFromVsyncToPhotons = system.GetFloatTrackedDeviceProperty(OpenVR.k_unTrackedDeviceIndex_Hmd, ETrackedDeviceProperty.Prop_SecondsFromVsyncToPhotons_Float, ref error);
+            if (error != ETrackedPropertyError.TrackedProp_Success)
+                secondsFromVsyncToPhotons = 0f;
+
+            float frameDuration = 1f / displayFrequency;
+            float predicted = frameDuration - secondsSinceLastVsync + secondsFromVsyncToPhotons;
+
+            if (predicted < 0f) predicted = 0f;
+            if (predicted > 0.05f) predicted = 0.05f;
+
+            return predicted;
         }
 
         /// <summary>

--- a/AlternativePlay/Models/TrackedDeviceManager.cs
+++ b/AlternativePlay/Models/TrackedDeviceManager.cs
@@ -98,18 +98,16 @@ namespace AlternativePlay.Models
             float predictedSecondsToPhotons = this.GetPredictedSecondsToPhotonsFromNow();
             this.openVRManager.System.GetDeviceToAbsoluteTrackingPose(ETrackingUniverseOrigin.TrackingUniverseStanding, predictedSecondsToPhotons, pTrackedDevicePoseArray);
 
-            int i = 0;
-            this.TrackedDevices.ForEach(device =>
+            foreach (var device in this.TrackedDevices)
             {
-                TrackedDevicePose_t? polledDevice = pTrackedDevicePoseArray.ElementAtOrDefault(i);
-                if (polledDevice != null)
-                {
-                    Vector3 position = polledDevice.Value.mDeviceToAbsoluteTracking.GetPosition();
-                    Quaternion rotation = polledDevice.Value.mDeviceToAbsoluteTracking.GetRotation();
-                    device.Pose = new Pose(position, rotation);
-                }
-                i++;
-            });
+                if (device.Index < 0 || device.Index >= pTrackedDevicePoseArray.Length)
+                    continue;
+
+                var polledDevice = pTrackedDevicePoseArray[device.Index];
+                Vector3 position = polledDevice.mDeviceToAbsoluteTracking.GetPosition();
+                Quaternion rotation = polledDevice.mDeviceToAbsoluteTracking.GetRotation();
+                device.Pose = new Pose(position, rotation);
+            }
         }
 
         /// <summary>
@@ -174,9 +172,12 @@ namespace AlternativePlay.Models
                 return null;
 
             uint index = this.openVRManager.System.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.LeftHand);
-            var device = this.TrackedDevices.ElementAtOrDefault((int)index);
+            if (index == OpenVR.k_unTrackedDeviceIndexInvalid)
+                return null;
 
-            if (device == null) { return null; }
+            var device = this.TrackedDevices.FirstOrDefault(d => d.Index == (int)index);
+            if (device == null)
+                return null;
 
             return device.Pose;
         }
@@ -187,9 +188,12 @@ namespace AlternativePlay.Models
                 return null;
 
             uint index = this.openVRManager.System.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.RightHand);
-            var device = this.TrackedDevices.ElementAtOrDefault((int)index);
+            if (index == OpenVR.k_unTrackedDeviceIndexInvalid)
+                return null;
 
-            if (device == null) { return null; }
+            var device = this.TrackedDevices.FirstOrDefault(d => d.Index == (int)index);
+            if (device == null)
+                return null;
 
             return device.Pose;
         }

--- a/AlternativePlay/SaberDeviceManager.cs
+++ b/AlternativePlay/SaberDeviceManager.cs
@@ -1,4 +1,4 @@
-﻿using AlternativePlay.HarmonyPatches;
+using AlternativePlay.HarmonyPatches;
 using AlternativePlay.Models;
 using System;
 using UnityEngine;
@@ -26,6 +26,18 @@ namespace AlternativePlay
         private Pose savedRightController;
         private Pose savedRightSaber;
         private bool calibrated;
+
+        /// <summary>
+        /// Controller-local position (meters) so saber aligns with vanilla when in-game saber position X/Y are 0.
+        /// Matches ≈ −5 cm on X and Y in Beat Saber settings (see CalibrateSaberPositions / Get* controller path).
+        /// </summary>
+        private static readonly Vector3 ControllerLocalSaberPositionCorrectionMeters = new Vector3(-0.05f, -0.05f, 0f);
+
+        /// <summary>
+        /// Quest 3 (Oculus Touch) via OpenVR: tracked pose is ring-centric; blade origin sits above the grip when X points up.
+        /// Extra local rotation (degrees) aligns saber with hand (tune if needed).
+        /// </summary>
+        private static readonly Vector3 Quest3ControllerGripEulerDegrees = new Vector3(-28f, 0f, 0f);
 
         private void Start()
         {
@@ -63,6 +75,8 @@ namespace AlternativePlay
                 // Return adjusted position from the saber
                 Pose controllerPose = this.trackedDeviceManager.GetPoseFromLeftController() ?? new Pose();
                 Pose adjustedControllerPose = this.AdjustForPlayerOrigin(controllerPose);
+                adjustedControllerPose = ApplyControllerLocalSaberPositionCorrection(adjustedControllerPose);
+                adjustedControllerPose = ApplyQuest3ControllerGripRotation(adjustedControllerPose);
                 return TrackedDeviceManager.GetTrackedObjectPose(this.savedLeftSaber, this.savedLeftController, adjustedControllerPose);
             }
         }
@@ -89,6 +103,8 @@ namespace AlternativePlay
                 // Return adjusted position from the saber
                 Pose controllerPose = this.trackedDeviceManager.GetPoseFromRightController() ?? new Pose();
                 Pose adjustedControllerPose = this.AdjustForPlayerOrigin(controllerPose);
+                adjustedControllerPose = ApplyControllerLocalSaberPositionCorrection(adjustedControllerPose);
+                adjustedControllerPose = ApplyQuest3ControllerGripRotation(adjustedControllerPose);
                 return TrackedDeviceManager.GetTrackedObjectPose(this.savedRightSaber, this.savedRightController, adjustedControllerPose);
             }
         }
@@ -168,12 +184,16 @@ namespace AlternativePlay
         {
             this.calibrated = true;
 
-            // Save current controller position
+            // Save current controller position (same correction as GetLeft/RightSaberPose controller path)
             this.savedLeftController = this.trackedDeviceManager.GetPoseFromLeftController() ?? new Pose();
             this.savedLeftController = this.AdjustForPlayerOrigin(this.savedLeftController);
+            this.savedLeftController = ApplyControllerLocalSaberPositionCorrection(this.savedLeftController);
+            this.savedLeftController = ApplyQuest3ControllerGripRotation(this.savedLeftController);
 
             this.savedRightController = this.trackedDeviceManager.GetPoseFromRightController() ?? new Pose();
             this.savedRightController = this.AdjustForPlayerOrigin(this.savedRightController);
+            this.savedRightController = ApplyControllerLocalSaberPositionCorrection(this.savedRightController);
+            this.savedRightController = ApplyQuest3ControllerGripRotation(this.savedRightController);
 
             // Save current game saber positions
             this.savedLeftSaber.position = this.saberManager.leftSaber.transform.position;
@@ -203,6 +223,18 @@ namespace AlternativePlay
             }
 
             return newDevicePose;
+        }
+
+        private static Pose ApplyControllerLocalSaberPositionCorrection(Pose pose)
+        {
+            pose.position += pose.rotation * ControllerLocalSaberPositionCorrectionMeters;
+            return pose;
+        }
+
+        private static Pose ApplyQuest3ControllerGripRotation(Pose pose)
+        {
+            pose.rotation *= Quaternion.Euler(Quest3ControllerGripEulerDegrees);
+            return pose;
         }
     }
 }

--- a/AlternativePlay/SaberDeviceManager.cs
+++ b/AlternativePlay/SaberDeviceManager.cs
@@ -28,6 +28,14 @@ namespace AlternativePlay
         private bool calibrated;
 
         /// <summary>
+        /// After Game scene load, wait this many <see cref="UnityEngine.MonoBehaviour.LateUpdate"/> frames before
+        /// snapping controller/saber poses so vanilla and tracking have settled (reduces rare bad calibration).
+        /// </summary>
+        private const int LateUpdateCalibrationDelayFrames = 3;
+
+        private int framesRemainingUntilCalibration;
+
+        /// <summary>
         /// Controller-local position (meters) so saber aligns with vanilla when in-game saber position X/Y are 0.
         /// Matches ≈ −5 cm on X and Y in Beat Saber settings (see CalibrateSaberPositions / Get* controller path).
         /// </summary>
@@ -51,6 +59,7 @@ namespace AlternativePlay
         private void Start()
         {
             this.calibrated = false;
+            this.framesRemainingUntilCalibration = LateUpdateCalibrationDelayFrames;
             this.trackedDeviceManager.LoadTrackedDeviceProperties();
             this.saberManager = MultiplayerLocalActivePlayerGameplayManagerPatch.multiplayerSaberManager ?? FindObjectOfType<SaberManager>();
             this.playerOrigin = GameObject.Find("LocalPlayerGameCore/Origin");
@@ -59,7 +68,27 @@ namespace AlternativePlay
         private void Update()
         {
             this.trackedDeviceManager.PollTrackedDevices();
-            if (!this.calibrated) this.CalibrateSaberPositions();
+        }
+
+        private void LateUpdate()
+        {
+            if (this.calibrated)
+                return;
+
+            if (this.framesRemainingUntilCalibration > 0)
+            {
+                this.framesRemainingUntilCalibration--;
+                if (this.framesRemainingUntilCalibration > 0)
+                    return;
+            }
+
+            if (this.saberManager == null)
+            {
+                this.framesRemainingUntilCalibration = 1;
+                return;
+            }
+
+            this.CalibrateSaberPositions();
         }
 
         /// <summary>

--- a/AlternativePlay/SaberDeviceManager.cs
+++ b/AlternativePlay/SaberDeviceManager.cs
@@ -1,4 +1,4 @@
-using AlternativePlay.HarmonyPatches;
+﻿using AlternativePlay.HarmonyPatches;
 using AlternativePlay.Models;
 using System;
 using UnityEngine;
@@ -38,6 +38,15 @@ namespace AlternativePlay
         /// Extra local rotation (degrees) aligns saber with hand (tune if needed).
         /// </summary>
         private static readonly Vector3 Quest3ControllerGripEulerDegrees = new Vector3(-28f, 0f, 0f);
+
+         /// <summary>
+        /// Re-polls OpenVR poses. Two-controller Darth Maul calls this from <see cref="UnityEngine.MonoBehaviour.LateUpdate"/>
+        /// so both-hand saber transforms use the freshest controller data in the frame.
+        /// </summary>
+        public void PollTrackedDevices()
+        {
+            this.trackedDeviceManager.PollTrackedDevices();
+        }
 
         private void Start()
         {

--- a/AlternativePlay/UI/AlternativePlayView.cs
+++ b/AlternativePlay/UI/AlternativePlayView.cs
@@ -1,4 +1,4 @@
-﻿using AlternativePlay.Models;
+using AlternativePlay.Models;
 using BeatSaberMarkupLanguage.Attributes;
 using BeatSaberMarkupLanguage.Components;
 using BeatSaberMarkupLanguage.ViewControllers;
@@ -63,7 +63,7 @@ namespace AlternativePlay.UI
         [UIComponent(nameof(SelectModeList))]
         public readonly CustomCellListTableData SelectModeList;
 
-        [UIAction(nameof(this.OnModeClicked))]
+        [UIAction(nameof(OnModeClicked))]
         public void OnModeClicked(TableView _, PlayModeSelectOption selected)
         {
             var playModeSettings = this.configuration.GetPlayModeSetting(selected.Index);
@@ -76,7 +76,7 @@ namespace AlternativePlay.UI
             this.mainFlowCoordinator.ShowPlayModeSelect(playModeSettings, selected.Index);
         }
 
-        [UIAction(nameof(this.OnAddNewConfiguration))]
+        [UIAction(nameof(OnAddNewConfiguration))]
         public void OnAddNewConfiguration()
         {
             // Add a new setting to the bottom of the list

--- a/AlternativePlay/UI/PlayModeSelectOption.cs
+++ b/AlternativePlay/UI/PlayModeSelectOption.cs
@@ -1,4 +1,4 @@
-﻿using AlternativePlay.Models;
+using AlternativePlay.Models;
 using BeatSaberMarkupLanguage.Attributes;
 using System;
 
@@ -28,13 +28,13 @@ namespace AlternativePlay.UI
             this.DeleteCallback = deleteCallback;
         }
 
-        [UIValue(nameof(this.Mode))]
+        [UIValue(nameof(Mode))]
         public string Mode { get; set; }
 
-        [UIValue(nameof(this.SelectedColor))]
+        [UIValue(nameof(SelectedColor))]
         public string SelectedColor => this.configurationData.Selected == this.Index ? "#FFFFFF" : "#7F7F7F";
 
-        [UIAction(nameof(this.OnDeleteClicked))]
+        [UIAction(nameof(OnDeleteClicked))]
         public void OnDeleteClicked()
         {
             if (this.DeleteCallback != null) this.DeleteCallback(this.Index);
@@ -58,29 +58,29 @@ namespace AlternativePlay.UI
             return this.IconSummary.GameModifierIcons[index];
         }
 
-        [UIValue(nameof(this.PlayModeIcon00))]
+        [UIValue(nameof(PlayModeIcon00))]
         public string PlayModeIcon00 => this.GetPlayModeIcon(0);
-        [UIValue(nameof(this.PlayModeIcon01))]
+        [UIValue(nameof(PlayModeIcon01))]
         public string PlayModeIcon01 => this.GetPlayModeIcon(1);
-        [UIValue(nameof(this.PlayModeIcon02))]
+        [UIValue(nameof(PlayModeIcon02))]
         public string PlayModeIcon02 => this.GetPlayModeIcon(2);
-        [UIValue(nameof(this.PlayModeIcon03))]
+        [UIValue(nameof(PlayModeIcon03))]
         public string PlayModeIcon03 => this.GetPlayModeIcon(3);
 
-        [UIValue(nameof(this.TrackerIcon00))]
+        [UIValue(nameof(TrackerIcon00))]
         public string TrackerIcon00 => this.GetTrackerIcon(0);
-        [UIValue(nameof(this.TrackerIcon01))]
+        [UIValue(nameof(TrackerIcon01))]
         public string TrackerIcon01 => this.GetTrackerIcon(1);
 
-        [UIValue(nameof(this.GameModifierIcon00))]
+        [UIValue(nameof(GameModifierIcon00))]
         public string GameModifierIcon00 => this.GetGameModifierIcon(0);
-        [UIValue(nameof(this.GameModifierIcon01))]
+        [UIValue(nameof(GameModifierIcon01))]
         public string GameModifierIcon01 => this.GetGameModifierIcon(1);
-        [UIValue(nameof(this.GameModifierIcon02))]
+        [UIValue(nameof(GameModifierIcon02))]
         public string GameModifierIcon02 => this.GetGameModifierIcon(2);
-        [UIValue(nameof(this.GameModifierIcon03))]
+        [UIValue(nameof(GameModifierIcon03))]
         public string GameModifierIcon03 => this.GetGameModifierIcon(3);
-        [UIValue(nameof(this.GameModifierIcon04))]
+        [UIValue(nameof(GameModifierIcon04))]
         public string GameModifierIcon04 => this.GetGameModifierIcon(4);
 
     }

--- a/AlternativePlay/UI/TrackerSelectView.cs
+++ b/AlternativePlay/UI/TrackerSelectView.cs
@@ -1,4 +1,4 @@
-﻿using AlternativePlay.Models;
+using AlternativePlay.Models;
 using BeatSaberMarkupLanguage.Attributes;
 using BeatSaberMarkupLanguage.Components;
 using BeatSaberMarkupLanguage.ViewControllers;
@@ -166,13 +166,13 @@ namespace AlternativePlay.UI
 
     public class TrackerSelectItem
     {
-        [UIValue(nameof(this.Icon))]
+        [UIValue(nameof(Icon))]
         public string Icon { get; set; }
 
-        [UIValue(nameof(this.Serial))]
+        [UIValue(nameof(Serial))]
         public string Serial { get; set; }
 
-        [UIValue(nameof(this.FullName))]
+        [UIValue(nameof(FullName))]
         public string FullName { get; set; }
     }
 }


### PR DESCRIPTION
# Report (English)

### Summary

- **Tracking**: Fixed OpenVR pose indexing (`pTrackedDevicePoseArray[device.Index]`). Left/right controllers resolved by `TrackedDevices.FirstOrDefault(d => d.Index == (int)index)` with invalid-index checks.
- **Pose prediction**: `GetPredictedSecondsToPhotonsFromNow` computes predicted seconds for `GetDeviceToAbsoluteTrackingPose`; tunable via static fields (bias + clamp).
- **Sabers**: Controller path applies local position correction (~−5 cm X/Y) and Quest 3 local rotation; initial calibration is delayed by a few `LateUpdate` frames.
- **Darth Maul**: Two-controller mode repolls in `LateUpdate` then runs `TransformTwoControllerMaul`; one-controller path stays in `Update` only.
- **Haptics**: Two-controller Darth Maul does not remap `XRNode`; one-controller remap unchanged.
- **Build**: BSML attributes use `nameof(Member)` instead of `nameof(this.Member)` to fix CS0027.

### `AlternativePlay/AlternativePlay.csproj`

| Lines | Description |
|-------|-------------|
| 170–173 | Reference `Unity.XR.OpenVR` with `HintPath` `$(BeatSaberDir)\Libs\Unity.XR.OpenVR.dll`. |

### `AlternativePlay/Models/OpenVRManager.cs`

| Lines | Description |
|-------|-------------|
| 14–22 | `OpenVR.Init` with `VRApplication_Other`; logs on init error. |

### `AlternativePlay/Models/TrackedDeviceManager.cs`

| Lines | Description |
|-------|-------------|
| 37–46 | Static tuning: `FallbackDisplayFrequencyHz`, `MinPredictionSeconds`, `MaxPredictionSeconds`, `PredictionBiasSeconds`. |
| 59–65 | If `System` is null, clears `TrackedDevices`. |
| 105–124 | `PollTrackedDevices`: reads each pose at `pTrackedDevicePoseArray[device.Index]`. |
| 132–159 | `GetPredictedSecondsToPhotonsFromNow`: VSync-based prediction, adds `PredictionBiasSeconds`, clamps to min/max. |
| 185–214 | `GetPoseFromLeftController` / `GetPoseFromRightController`: invalid index guard; `FirstOrDefault(d => d.Index == (int)index)`. |

### `AlternativePlay/SaberDeviceManager.cs`

| Lines | Description |
|-------|-------------|
| 30–48 | `LateUpdateCalibrationDelayFrames`, `ControllerLocalSaberPositionCorrectionMeters`, `Quest3ControllerGripEulerDegrees`. |
| 50–57 | Public `PollTrackedDevices()` forwarding to `trackedDeviceManager`. |
| 59–92 | `Start`, `Update` (poll each frame), `LateUpdate` (delayed `CalibrateSaberPositions`). |
| 99–119, 127–147 | `GetLeftSaberPose` / `GetRightSaberPose`: controller path applies corrections then `GetTrackedObjectPose`. |
| 221–234 | `CalibrateSaberPositions`: same corrections on saved controller poses. |
| 266–276 | `ApplyControllerLocalSaberPositionCorrection`, `ApplyQuest3ControllerGripRotation`. |

### `AlternativePlay/DarthMaulBehavior.cs`

| Lines | Description |
|-------|-------------|
| 52–64 | `LateUpdate`: only when Darth Maul, not split, and `ControllerCount == Two`; calls `PollTrackedDevices` and `TransformTwoControllerMaul`. |
| 69–90 | `TransformSabers`: split / one / two controller branches. |

### `AlternativePlay/HarmonyPatches/DarthMaulHapticPatch.cs`

| Lines | Description |
|-------|-------------|
| 16–38 | One-controller mode: remap `XRNode` for left/right. |
| 41–42 | Two-controller mode: no haptic remapping (comment). |

### BSML (CS0027)

Attribute arguments cannot use `this`; replaced `nameof(this.Member)` with `nameof(Member)`.
*This build failed in my environment.

| File | Lines (representative) |
|------|-------------------------|
| `AlternativePlay/UI/AlternativePlayView.cs` | 63–66, 79 |
| `AlternativePlay/UI/PlayModeSelectOption.cs` | 31–37, 61–83 |
| `AlternativePlay/UI/TrackerSelectView.cs` | 169–175 |

---

### Summary
- **OpenVR pose prediction**: Added static tuning fields on `TrackedDeviceManager`; `GetPredictedSecondsToPhotonsFromNow` uses them (bias + clamp).
- **Darth Maul**: `LateUpdate` runs two-controller repoll/transform **only** when `ControllerCount == Two` (lines 58–60 return for one-controller).
- **Darth Maul haptics**: Two-controller mode does not remap `XRNode`; one-controller remap remains.

### 1. `AlternativePlay/Models/TrackedDeviceManager.cs`

| Lines | Description |
|-------|-------------|
| 34–46 | Static tuning: `FallbackDisplayFrequencyHz`, `MinPredictionSeconds`, `MaxPredictionSeconds`, `PredictionBiasSeconds` |
| 105–125 | `PollTrackedDevices`: predicted seconds passed to `GetDeviceToAbsoluteTrackingPose` |
| 127–160 | `GetPredictedSecondsToPhotonsFromNow`: fallback Hz, `PredictionBiasSeconds`, min/max clamp |

### 2. `AlternativePlay/DarthMaulBehavior.cs`

| Lines | Description |
|-------|-------------|
| 52–64 | `LateUpdate`: only for `ControllerCount == Two`; early return 58–60 for non-Two |

### 3. `AlternativePlay/HarmonyPatches/DarthMaulHapticPatch.cs`

| Lines | Description |
|-------|-------------|
| 16–39 | One-controller: remap `XRNode`, return |
| 41–42 | Two-controller: no haptic remapping (comment); old two+reverse swap removed |

---

## Scope

- Changed file: `AlternativePlay/SaberDeviceManager.cs`
- Approximate size: about **278 lines** (may differ by ±1 depending on a trailing newline)

## Background

We investigated rare saber misalignment that appears only shortly after entering the Game scene. The hypothesis is that the first `CalibrateSaberPositions()` runs **too early**—before vanilla saber placement and tracking have settled—so the saved controller/saber snapshot can be wrong for the rest of the session. This change **defers the first calibration**.

## What changed (approximate line numbers)

- **~30–36**: Added `LateUpdateCalibrationDelayFrames` (currently **3**) and `framesRemainingUntilCalibration`, with a brief comment.
- **~59–66**: `Start()` initializes `framesRemainingUntilCalibration`.
- **~68–71**: `Update()` only calls `PollTrackedDevices()`; no immediate calibration.
- **~73–92**: `LateUpdate()` waits, then calls `CalibrateSaberPositions()`. If `saberManager` is null, set `framesRemainingUntilCalibration` to **1** and retry next frame.

## Tuning

Edit `LateUpdateCalibrationDelayFrames` to change how many `LateUpdate` frames to wait before the first calibration.

---

---

# 変更内容レポート（日本語）


### 概要

- **トラッキング**: OpenVR のポーズ取得でデバイスインデックスと配列の対応を修正。左右コントローラーはリスト添字ではなく `Index` で照合。
- **姿勢予測**: `GetPredictedSecondsToPhotonsFromNow` で表示タイミング向けの予測秒を算出し、静的フィールドでチューニング可能にした。
- **セイバー**: コントローラー経路でゲーム内オフセットに近い局所位置補正と Quest 3 向けローカル回転補正。初回キャリブは `LateUpdate` で数フレーム遅延。
- **ダースモール**: 両手モードのみ `LateUpdate` で再ポール後に両手用変形。片手は `Update` のみ。
- **ハプティック**: 両手ダースモールでは `XRNode` の付け替えを行わない。
- **ビルド**: BSML 属性内の `nameof(this.…)` を `nameof(…)` に変更（CS0027 回避）。

### `AlternativePlay/AlternativePlay.csproj`

| 行 | 内容 |
|----|------|
| 170–173 | `Unity.XR.OpenVR` 参照。`HintPath` は `$(BeatSaberDir)\Libs\Unity.XR.OpenVR.dll`。 |

### `AlternativePlay/Models/OpenVRManager.cs`

| 行 | 内容 |
|----|------|
| 14–22 | `OpenVR.Init`（`VRApplication_Other`）。初期化エラー時はログ出力。 |

### `AlternativePlay/Models/TrackedDeviceManager.cs`

| 行 | 内容 |
|----|------|
| 37–46 | 予測チューニング用静的フィールド（`FallbackDisplayFrequencyHz`, `MinPredictionSeconds`, `MaxPredictionSeconds`, `PredictionBiasSeconds`）。 |
| 59–65 | `System == null` 時はトラッキングデバイス一覧を空に。 |
| 105–124 | `PollTrackedDevices`: `pTrackedDevicePoseArray[device.Index]` で各デバイスのポーズを取得。 |
| 132–159 | `GetPredictedSecondsToPhotonsFromNow`: VSync 等から予測秒を算出し、`PredictionBiasSeconds` を加算後に min/max でクランプ。 |
| 185–214 | `GetPoseFromLeftController` / `GetPoseFromRightController`: 無効インデックスを除外し、`FirstOrDefault(d => d.Index == (int)index)` でデバイスを特定。 |

### `AlternativePlay/SaberDeviceManager.cs`

| 行 | 内容 |
|----|------|
| 30–48 | `LateUpdateCalibrationDelayFrames`、コントローラー局所位置補正（約 −5cm X/Y）、Quest 3 用オイラー角定数。 |
| 50–57 | 公開 `PollTrackedDevices()`（両手ダースモールの `LateUpdate` から呼び出し可）。 |
| 59–92 | `Start` / `Update`（毎フレーム `PollTrackedDevices`）/ `LateUpdate`（遅延後に `CalibrateSaberPositions`）。 |
| 99–119, 127–147 | `GetLeftSaberPose` / `GetRightSaberPose`: コントローラー経路で補正の後 `GetTrackedObjectPose`。 |
| 221–234 | `CalibrateSaberPositions`: 保存するコントローラー姿勢に同じ補正を適用。 |
| 266–276 | `ApplyControllerLocalSaberPositionCorrection`、`ApplyQuest3ControllerGripRotation`。 |

### `AlternativePlay/DarthMaulBehavior.cs`

| 行 | 内容 |
|----|------|
| 52–64 | `LateUpdate`: ダースモール・非スプリット・**両手**のときのみ `PollTrackedDevices` と `TransformTwoControllerMaul`。両手以外（片手など）は 59–60 行で return。 |
| 69–90 | `TransformSabers`: スプリット / 片手 / 両手の分岐。 |

### `AlternativePlay/HarmonyPatches/DarthMaulHapticPatch.cs`

| 行 | 内容 |
|----|------|
| 16–38 | 片手モード時のみ `XRNode` を左右で付け替え。 |
| 41–42 | 両手モードではハプティックの左右入れ替えを行わない（コメント）。 |

### BSML（CS0027 対応）

属性引数内では `this` が使えないため、`nameof(this.メンバー)` を `nameof(メンバー)` に変更。
※こちらは私の環境でビルドが通らなかったため

| ファイル | 行（代表） |
|----------|--------------|
| `AlternativePlay/UI/AlternativePlayView.cs` | 63–66, 79 |
| `AlternativePlay/UI/PlayModeSelectOption.cs` | 31–37, 61–83 |
| `AlternativePlay/UI/TrackerSelectView.cs` | 169–175 |

---

### 概要
- **OpenVR 姿勢予測**: `TrackedDeviceManager` に予測時間のチューニング用静的フィールドを追加し、`GetPredictedSecondsToPhotonsFromNow` で参照。
- **ダースモール**: 1コントローラー時に `LateUpdate` で両手用変形が上書きされないようガードを追加。
- **ダースモール・ハプティック**: 両手モードでは `XRNode` の付け替えを行わない（片手モードのリマップのみ維持）。

### 1. `AlternativePlay/Models/TrackedDeviceManager.cs`

| 行 | 内容 |
|----|------|
| 34–46 | 予測チューニング用 `public static` フィールド: `FallbackDisplayFrequencyHz`, `MinPredictionSeconds`, `MaxPredictionSeconds`, `PredictionBiasSeconds` |
| 105–125 | `PollTrackedDevices`: `GetPredictedSecondsToPhotonsFromNow()` の結果を `GetDeviceToAbsoluteTrackingPose` の第2引数に使用 |
| 127–160 | `GetPredictedSecondsToPhotonsFromNow`: 表示周波数フォールバックを `FallbackDisplayFrequencyHz` に、`PredictionBiasSeconds` 加算後に min/max クランプ |

### 2. `AlternativePlay/DarthMaulBehavior.cs`

| 行 | 内容 |
|----|------|
| 52–64 | `LateUpdate`: `ControllerCount == Two` のときのみ `PollTrackedDevices` + `TransformTwoControllerMaul`。One のときは 58–60 で `return` |

### 3. `AlternativePlay/HarmonyPatches/DarthMaulHapticPatch.cs`

| 行 | 内容 |
|----|------|
| 16–39 | `PlayMode.DarthMaul` かつ非 Split 時: 1コントローラーだけ `XRNode` を付け替え、`return` |
| 41–42 | 両手コントローラー: ハプティックの左右入れ替えなし（コメント）。以前の「両手＋リバースで swap」ブロックは削除済み |

---

## 対象

- 変更ファイル: `AlternativePlay/SaberDeviceManager.cs`
- 行数の目安: 約 **278 行**（末尾の空行の有無で ±1 することがあります）

## 背景

Game シーンへ入った直後にだけ稀に起きるセイバー位置のずれについて、初回の `CalibrateSaberPositions()` が早すぎて、本体側のセイバー配置やトラッキングが安定する前にコントローラとセイバーのスナップショットが取られている可能性を疑い、**初回キャリブのタイミングを遅らせる**変更を行いました。

## 変更の要点（行番号の目安）

- **30〜36 行付近**: 定数 `LateUpdateCalibrationDelayFrames`（現在は **3**）と `framesRemainingUntilCalibration` を追加。コメントで意図を記載。
- **59〜66 行付近**: `Start()` で `framesRemainingUntilCalibration` を初期化（既存の `Start` 処理と併せて）。
- **68〜71 行付近**: `Update()` は `PollTrackedDevices()` のみ。初回キャリブは呼ばない。
- **73〜92 行付近**: `LateUpdate()` でカウンタを減らし、待機後に `CalibrateSaberPositions()`。`saberManager` が null のときは `framesRemainingUntilCalibration` を **1** に戻して次フレームで再試行。

## 調整方法

待機フレーム数は `LateUpdateCalibrationDelayFrames` の数値を変更すれば調整できます。

---


