### PR TITLE
遅延の再調整とトラッカー割り当てがdefaultのときのデバイスの取得方法を変更

### DIFF
--- a/AlternativePlay/Models/TrackedDeviceManager.cs
+++ b/AlternativePlay/Models/TrackedDeviceManager.cs
@@ -162,9 +162,6 @@ namespace AlternativePlay.Models
             return device.Pose;
         }
 
-        /// <summary>
-        /// Unity XR 入力（OpenXR 起動時など）から左手コントローラの pose のみを取得する。取得できなければ null。
-        /// </summary>
         public Pose? GetPoseFromOpenXrLeftController()
         {
             if (TryGetOpenXrControllerPose(InputDeviceCharacteristics.HeldInHand | InputDeviceCharacteristics.Controller | InputDeviceCharacteristics.Left, out Pose pose))
@@ -175,9 +172,6 @@ namespace AlternativePlay.Models
             return null;
         }
 
-        /// <summary>
-        /// Unity XR 入力（OpenXR 起動時など）から右手コントローラの pose のみを取得する。取得できなければ null。
-        /// </summary>
         public Pose? GetPoseFromOpenXrRightController()
         {
             if (TryGetOpenXrControllerPose(InputDeviceCharacteristics.HeldInHand | InputDeviceCharacteristics.Controller | InputDeviceCharacteristics.Right, out Pose pose))

--- a/AlternativePlay/Models/TrackedDeviceManager.cs
+++ b/AlternativePlay/Models/TrackedDeviceManager.cs
@@ -38,6 +38,7 @@ namespace AlternativePlay.Models
 #pragma warning restore CS0649
 
         public List<OpenVRDeviceInfo> TrackedDevices { get; private set; } = new List<OpenVRDeviceInfo>();
+        public List<UnityEngine.XR.InputDevice> OpenXrDevices { get; private set; } = new List<UnityEngine.XR.InputDevice>();
 
         /// <summary>
         /// Updates the list of valid tracked devices and their properties only.  Use <see cref="PollTrackedDevices"/> to get the
@@ -143,11 +144,6 @@ namespace AlternativePlay.Models
 
         public Pose? GetPoseFromLeftController()
         {
-            if (TryGetOpenXrControllerPose(InputDeviceCharacteristics.HeldInHand | InputDeviceCharacteristics.Controller | InputDeviceCharacteristics.Left, out Pose openXrPose))
-            {
-                return openXrPose;
-            }
-
             uint index = this.openVRManager.System.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.LeftHand);
             var device = this.TrackedDevices.ElementAtOrDefault((int)index);
 
@@ -158,11 +154,6 @@ namespace AlternativePlay.Models
 
         public Pose? GetPoseFromRightController()
         {
-            if (TryGetOpenXrControllerPose(InputDeviceCharacteristics.HeldInHand | InputDeviceCharacteristics.Controller | InputDeviceCharacteristics.Right, out Pose openXrPose))
-            {
-                return openXrPose;
-            }
-
             uint index = this.openVRManager.System.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.RightHand);
             var device = this.TrackedDevices.FirstOrDefault(d => d.Index == (int)index);
 
@@ -171,20 +162,48 @@ namespace AlternativePlay.Models
             return device.Pose;
         }
 
-        private static bool TryGetOpenXrControllerPose(InputDeviceCharacteristics characteristics, out Pose pose)
+        /// <summary>
+        /// Unity XR 入力（OpenXR 起動時など）から左手コントローラの pose のみを取得する。取得できなければ null。
+        /// </summary>
+        public Pose? GetPoseFromOpenXrLeftController()
         {
-            var devices = new List<InputDevice>();
+            if (TryGetOpenXrControllerPose(InputDeviceCharacteristics.HeldInHand | InputDeviceCharacteristics.Controller | InputDeviceCharacteristics.Left, out Pose pose))
+            {
+                return pose;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Unity XR 入力（OpenXR 起動時など）から右手コントローラの pose のみを取得する。取得できなければ null。
+        /// </summary>
+        public Pose? GetPoseFromOpenXrRightController()
+        {
+            if (TryGetOpenXrControllerPose(InputDeviceCharacteristics.HeldInHand | InputDeviceCharacteristics.Controller | InputDeviceCharacteristics.Right, out Pose pose))
+            {
+                return pose;
+            }
+
+            return null;
+        }
+
+        private bool TryGetOpenXrControllerPose(InputDeviceCharacteristics characteristics, out Pose pose)
+        {
+            List<InputDevice> devices = this.OpenXrDevices;
             InputDevices.GetDevicesWithCharacteristics(characteristics, devices);
 
-            foreach (var device in devices)
+            var device = devices.FirstOrDefault(d =>
+                d.TryGetFeatureValue(CommonUsages.devicePosition, out _) &&
+                d.TryGetFeatureValue(CommonUsages.deviceRotation, out _)
+            );
+
+            if (device.isValid)
             {
-                bool hasPosition = device.TryGetFeatureValue(CommonUsages.devicePosition, out Vector3 position);
-                bool hasRotation = device.TryGetFeatureValue(CommonUsages.deviceRotation, out Quaternion rotation);
-                if (hasPosition && hasRotation)
-                {
-                    pose = new Pose(position, rotation);
-                    return true;
-                }
+                device.TryGetFeatureValue(CommonUsages.devicePosition, out Vector3 position);
+                device.TryGetFeatureValue(CommonUsages.deviceRotation, out Quaternion rotation);
+                pose = new Pose(position, rotation);
+                return true;
             }
 
             pose = default;

--- a/AlternativePlay/Models/TrackedDeviceManager.cs
+++ b/AlternativePlay/Models/TrackedDeviceManager.cs
@@ -148,7 +148,6 @@ namespace AlternativePlay.Models
                 return openXrPose;
             }
 
-            if (this.openVRManager?.System == null) { return null; }
             uint index = this.openVRManager.System.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.LeftHand);
             var device = this.TrackedDevices.ElementAtOrDefault((int)index);
 
@@ -164,7 +163,6 @@ namespace AlternativePlay.Models
                 return openXrPose;
             }
 
-            if (this.openVRManager?.System == null) { return null; }
             uint index = this.openVRManager.System.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.RightHand);
             var device = this.TrackedDevices.FirstOrDefault(d => d.Index == (int)index);
 

--- a/AlternativePlay/Models/TrackedDeviceManager.cs
+++ b/AlternativePlay/Models/TrackedDeviceManager.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text;
 using UnityEngine;
+using UnityEngine.XR;
 using Valve.VR;
 using Zenject;
 using static Valve.VR.IVRSystem;
@@ -84,7 +85,9 @@ namespace AlternativePlay.Models
         /// </remarks>
         public void PollTrackedDevices()
         {
-            const float predictionBiasSeconds = 0.0255f;
+            const float minPredictionSeconds = 0.0f;
+            const float maxPredictionSeconds = 0.1f;
+            const float predictionBiasSeconds = 0.0225f;
 
             // Calculate time to predict into the future
             float secondsSinceLastVsync = 0.0f;
@@ -98,6 +101,9 @@ namespace AlternativePlay.Models
 
             float predictedSecondsFromNow = frameDuration - secondsSinceLastVsync + fVsyncToPhotons;
             predictedSecondsFromNow += predictionBiasSeconds;
+
+            if (predictedSecondsFromNow < minPredictionSeconds) { predictedSecondsFromNow = minPredictionSeconds; }
+            if (predictedSecondsFromNow > maxPredictionSeconds) { predictedSecondsFromNow = maxPredictionSeconds; }
 
             // Get all tracked device poses from OpenVR API
             TrackedDevicePose_t[] trackedDevicePoseArray = new TrackedDevicePose_t[OpenVR.k_unMaxTrackedDeviceCount];
@@ -137,6 +143,12 @@ namespace AlternativePlay.Models
 
         public Pose? GetPoseFromLeftController()
         {
+            if (TryGetOpenXrControllerPose(InputDeviceCharacteristics.HeldInHand | InputDeviceCharacteristics.Controller | InputDeviceCharacteristics.Left, out Pose openXrPose))
+            {
+                return openXrPose;
+            }
+
+            if (this.openVRManager?.System == null) { return null; }
             uint index = this.openVRManager.System.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.LeftHand);
             var device = this.TrackedDevices.ElementAtOrDefault((int)index);
 
@@ -147,12 +159,38 @@ namespace AlternativePlay.Models
 
         public Pose? GetPoseFromRightController()
         {
+            if (TryGetOpenXrControllerPose(InputDeviceCharacteristics.HeldInHand | InputDeviceCharacteristics.Controller | InputDeviceCharacteristics.Right, out Pose openXrPose))
+            {
+                return openXrPose;
+            }
+
+            if (this.openVRManager?.System == null) { return null; }
             uint index = this.openVRManager.System.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.RightHand);
-            var device = this.TrackedDevices.ElementAtOrDefault((int)index);
+            var device = this.TrackedDevices.FirstOrDefault(d => d.Index == (int)index);
 
             if (device == null) { return null; }
 
             return device.Pose;
+        }
+
+        private static bool TryGetOpenXrControllerPose(InputDeviceCharacteristics characteristics, out Pose pose)
+        {
+            var devices = new List<InputDevice>();
+            InputDevices.GetDevicesWithCharacteristics(characteristics, devices);
+
+            foreach (var device in devices)
+            {
+                bool hasPosition = device.TryGetFeatureValue(CommonUsages.devicePosition, out Vector3 position);
+                bool hasRotation = device.TryGetFeatureValue(CommonUsages.deviceRotation, out Quaternion rotation);
+                if (hasPosition && hasRotation)
+                {
+                    pose = new Pose(position, rotation);
+                    return true;
+                }
+            }
+
+            pose = default;
+            return false;
         }
 
         /// <summary>

--- a/AlternativePlay/SaberDeviceManager.cs
+++ b/AlternativePlay/SaberDeviceManager.cs
@@ -26,12 +26,6 @@ namespace AlternativePlay
         private Pose savedRightController;
         private Pose savedRightSaber;
         private bool calibrated;
-        private bool leftRuntimeOffsetReady;
-        private bool rightRuntimeOffsetReady;
-        private Vector3 leftRuntimeLocalOffsetPosition;
-        private Quaternion leftRuntimeLocalOffsetRotation;
-        private Vector3 rightRuntimeLocalOffsetPosition;
-        private Quaternion rightRuntimeLocalOffsetRotation;
 
         private void Start()
         {

--- a/AlternativePlay/SaberDeviceManager.cs
+++ b/AlternativePlay/SaberDeviceManager.cs
@@ -26,6 +26,12 @@ namespace AlternativePlay
         private Pose savedRightController;
         private Pose savedRightSaber;
         private bool calibrated;
+        private bool leftRuntimeOffsetReady;
+        private bool rightRuntimeOffsetReady;
+        private Vector3 leftRuntimeLocalOffsetPosition;
+        private Quaternion leftRuntimeLocalOffsetRotation;
+        private Vector3 rightRuntimeLocalOffsetPosition;
+        private Quaternion rightRuntimeLocalOffsetRotation;
 
         private void Start()
         {
@@ -61,7 +67,7 @@ namespace AlternativePlay
                 if (!this.calibrated) return new Pose();
 
                 // Return adjusted position from the saber
-                Pose controllerPose = this.trackedDeviceManager.GetPoseFromLeftController() ?? new Pose();
+                Pose controllerPose = this.trackedDeviceManager.GetPoseFromOpenXrLeftController() ?? this.trackedDeviceManager.GetPoseFromLeftController() ?? new Pose();
                 Pose adjustedControllerPose = this.AdjustForPlayerOrigin(controllerPose);
                 return TrackedDeviceManager.GetTrackedObjectPose(this.savedLeftSaber, this.savedLeftController, adjustedControllerPose);
             }
@@ -87,7 +93,7 @@ namespace AlternativePlay
                 if (!this.calibrated) return new Pose();
 
                 // Return adjusted position from the saber
-                Pose controllerPose = this.trackedDeviceManager.GetPoseFromRightController() ?? new Pose();
+                Pose controllerPose = this.trackedDeviceManager.GetPoseFromOpenXrRightController() ?? this.trackedDeviceManager.GetPoseFromRightController() ?? new Pose();
                 Pose adjustedControllerPose = this.AdjustForPlayerOrigin(controllerPose);
                 return TrackedDeviceManager.GetTrackedObjectPose(this.savedRightSaber, this.savedRightController, adjustedControllerPose);
             }


### PR DESCRIPTION
完全に元のセイバーとのずれを一致させた

トラッカー割り当てがdefaultの時は、OpenXRからデバイス取得するように変更